### PR TITLE
jak w readme

### DIFF
--- a/intervaltimer.vhd
+++ b/intervaltimer.vhd
@@ -1,0 +1,85 @@
+------ 0 to 12 million binary counter (timer) with a second timer, that counts seconds(0 to 60) and a third timer, that counts minutes (0 to 3)
+---!! IMPORTANT---changing the type from unsigend to std_logic_vector (around line 66)
+
+--tested only on small values (as below), don't know if works on actual minutes
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity intervaltimer is
+    port (
+        clk : in std_logic;
+        rst : in std_logic;
+        sec_digit_tens : out std_logic_vector(3 downto 0);
+        sec_digit_ones : out std_logic_vector(3 downto 0);
+        min_digit_ones : out std_logic_vector(3 downto 0)
+    );
+end intervaltimer;
+
+architecture rtl of intervaltimer is
+
+    constant counter_max 							: integer 					:= 15; --- changed for tb - should be  12 000 000 (depending on the clock cycle)
+    constant seconds_max 							: integer 					:= 12; --- changed for tb - should be 60 		
+	constant minutes_max 							: integer 					:= 3;									
+	
+	
+    signal minutes_counter 							: unsigned(7 downto 0)  := (others => '0');
+	signal seconds_counter 							: unsigned(7 downto 0)  := (others => '0');
+    signal counter 									: unsigned(24 downto 0) := (others => '0'); 
+
+	
+    signal signal_sec_counter : std_logic_vector(7 downto 0) := (others => '0'); 
+	signal signal_min_counter : std_logic_vector(7 downto 0) := (others => '0'); 
+
+begin
+			
+    one_sec_counter : process(clk, rst)
+    
+	begin 
+        
+		if rst = '1' or minutes_counter = minutes_max then 		-- if minutes = 3 then reset
+            counter 		<=  (others => '0');
+            seconds_counter <=  (others => '0');
+			minutes_counter <=  (others => '0');
+		  
+        else 
+				if rising_edge(clk) then 
+					if counter = counter_max then		-- when one second passes
+						
+								if seconds_counter = seconds_max then   				
+									seconds_counter <= (others => '0');					
+									minutes_counter <= minutes_counter + 1;				
+									counter 		<= (others => '0');					
+								else -- if seconds < seconds_max
+									seconds_counter <= seconds_counter + 1;	 --incrementation of seconds
+									counter 		<= (others => '0');				
+								end if;
+					else   -- if counter < counter_max -- during one second
+						counter <= counter + 1;
+							
+					end if;
+            	end if;
+        end if;
+    
+	end process;
+	
+    signal_sec_counter <= std_logic_vector(seconds_counter); 
+	signal_min_counter <= std_logic_vector(minutes_counter);
+
+    sec_to_bcd : entity work.bcdconverter(rtl) port map(   ---translating binary to bcd for seconds
+        clk				    => clk,
+		binary            => signal_sec_counter,
+        bcd1 				=> sec_digit_tens,
+        bcd0 				=> sec_digit_ones
+    );
+
+    min_to_bcd : entity work.bcdconverter(rtl) port map( ---translating binary to bcd for minutes, idk if really necessary, I'll leave it for possible later use 
+        clk				  => clk,
+		binary            => signal_min_counter,    
+        bcd0 			  => min_digit_ones 
+    );
+
+
+end architecture;

--- a/sec_to_bcd.vhd
+++ b/sec_to_bcd.vhd
@@ -1,0 +1,55 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.std_logic_unsigned.all;
+
+entity bcdconverter is
+    port (
+        clk     :  in std_logic;
+        binary  :  in std_logic_vector(7 downto 0);
+        bcd0    :  out std_logic_vector(3 downto 0);
+        bcd1    :  out std_logic_vector(3 downto 0)
+    );
+end bcdconverter;
+
+architecture rtl of bcdconverter  is
+
+    signal bin          : std_logic_vector(7 downto 0);
+    signal ones         : std_logic_vector(3 downto 0);
+    signal tens         : std_logic_vector(3 downto 0);
+    signal state        : std_logic_vector(1 downto 0); -- three sates - 1,2,3
+
+begin
+
+    converter : process(clk)
+    begin 
+        if rising_edge(clk) then
+            state <= state + '1';
+
+            case state is 
+                when "00" => --1st state
+                    bin <= binary;
+                    ones <= "0000";
+                    tens <= "0000";
+                
+                when "01" => --2nd state
+                    if bin >= "00001010" then -- if num > 10
+                        bin     <= bin - "00001010"; -- num = num - 10 
+                        tens    <= tens + '1';      -- tens counter incrementation
+                        state   <= "01";            --while num > 10 state stays the same
+                    else                            --if num - 10 < 10 
+                        ones <= bin(3 downto 0);   
+                    end if;
+                
+                when "10" => --3rd state
+                    bcd0 <= ones;       
+                    bcd1 <= tens;
+                
+                when others =>
+                    state <= "00";
+            end case;
+        end if;
+    end process;
+
+
+end architecture;

--- a/segmentdecoder.vhd
+++ b/segmentdecoder.vhd
@@ -1,0 +1,59 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity segmentdecoder is
+    port (
+        digit 		  :   in std_logic_vector(3 downto 0);
+        segment_A   :   out std_logic := '1';
+        segment_B   :   out std_logic := '1'; 
+        segment_C   :   out std_logic := '1';
+        segment_D   :   out std_logic := '1';
+        segment_E   :   out std_logic := '1';
+        segment_F   :   out std_logic := '1';
+        segment_G   :   out std_logic := '1'
+    );
+end segmentdecoder;
+
+architecture rtl of segmentdecoder is
+
+begin
+
+    process(digit)
+
+        variable decode_data : std_logic_vector(6 downto 0);
+
+        begin 
+        case digit is 
+            when "0000" => decode_data := "1111110"; -- 0 
+            when "0001" => decode_data := "0110000"; -- 1
+            when "0010" => decode_data := "1101101"; -- 2
+            when "0011" => decode_data := "1111001"; -- 3
+            when "0100" => decode_data := "0110011"; -- 4
+            when "0101" => decode_data := "1011011"; -- 5
+            when "0110" => decode_data := "1011111"; -- 6
+            when "0111" => decode_data := "1110000"; -- 7
+            when "1000" => decode_data := "1111111"; -- 8
+            when "1001" => decode_data := "1111011"; -- 9
+            --------------uncomment if needed ------------------------
+            --when "1010" => decode_data := "1111110"; -- A
+            --when "1011" => decode_data := "1111110"; -- B
+            --when "1100" => decode_data := "1111110"; -- C
+            --when "1101" => decode_data := "1111110"; -- D
+            --when "1110" => decode_data := "1111110"; -- E            
+            --when "1111" => decode_data := "1111110"; -- F
+            ----------------------------------------------------------
+            when others => decode_data := "0111110"; -- error H
+        end case;
+
+        segment_A <= not decode_data(6); -- not operator because it's active low
+        segment_B <= not decode_data(5);
+        segment_C <= not decode_data(4);
+        segment_D <= not decode_data(3);
+        segment_E <= not decode_data(2);
+        segment_F <= not decode_data(1);
+        segment_G <= not decode_data(0);
+    
+    end process;
+
+end architecture;

--- a/segmentdriver.vhd
+++ b/segmentdriver.vhd
@@ -1,0 +1,120 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity segmentdriver is
+    port (
+        clk : in std_logic;
+        rst : in std_logic;
+        
+        minutes         : out std_logic_vector(3 downto 0) :="0000";
+        seconds_ones    : out std_logic_vector(3 downto 0) :="0000";
+        seconds_tens    : out std_logic_vector(3 downto 0) :="0000";
+
+        seg_A   :   out std_logic;
+        seg_B   :   out std_logic;
+        seg_C   :   out std_logic;
+        seg_D   :   out std_logic;
+        seg_E   :   out std_logic;
+        seg_F   :   out std_logic;
+        seg_G   :   out std_logic;
+		  
+		  seg_soA   :   out std_logic;
+        seg_soB   :   out std_logic;
+        seg_soC   :   out std_logic;
+        seg_soD   :   out std_logic;
+        seg_soE   :   out std_logic;
+        seg_soF   :   out std_logic;
+        seg_soG   :   out std_logic;
+		  
+		  seg_stA   :   out std_logic;
+        seg_stB   :   out std_logic;
+        seg_stC   :   out std_logic;
+        seg_stD   :   out std_logic;
+        seg_stE   :   out std_logic;
+        seg_stF   :   out std_logic;
+        seg_stG   :   out std_logic;
+
+        select_display_MINUTES         : out std_logic;
+        select_display_SECONDS_ONES    : out std_logic;
+        select_display_SECONDS_TENS    : out std_logic
+    );
+end segmentdriver;
+
+architecture rtl of segmentdriver is
+	
+	signal temp_minutes : std_logic_vector(3 downto 0);
+	signal temp_sones : std_logic_vector(3 downto 0);
+	signal temp_stens : std_logic_vector(3 downto 0);
+---- ZROBIC KOMPONENT
+
+	component segmentdecoder
+	port(		digit : in std_logic_vector(3 downto 0);
+            segment_A : out std_logic;
+            segment_B  : out std_logic;
+            segment_C   : out std_logic;
+            segment_D  : out std_logic;
+            segment_E   : out std_logic;
+				segment_F : out std_logic;
+				segment_G  : out std_logic	
+		);
+	end component;
+	
+begin
+	
+
+	wojtyla : entity work.intervaltimer(rtl) port map(
+        rst             	=> rst,
+        clk             	=> clk,
+        sec_digit_tens   	=> temp_stens,
+        sec_digit_ones   	=> temp_sones,
+		  min_digit_ones		=>  temp_minutes
+    );
+
+        -- component instatiation
+		
+        uutmins : segmentdecoder port map(
+				digit => temp_minutes,
+            segment_A   =>  seg_A,
+            segment_B   =>  seg_B,
+            segment_C   =>  seg_C,
+            segment_D   =>  seg_D,
+            segment_E   =>  seg_E,
+				segment_F   =>  seg_F,
+				segment_G   =>  seg_G
+        );
+
+        uutsones : segmentdecoder port map(
+            digit => temp_sones,
+            segment_A   =>  seg_soA,
+            segment_B   =>  seg_soB,
+            segment_C   =>  seg_soC,
+            segment_D   =>  seg_soD,
+            segment_E   =>  seg_soE,
+				segment_F   =>  seg_soF,
+				segment_G   =>  seg_soG
+        );
+
+        uutstens : segmentdecoder port map(
+          digit => temp_stens,
+          segment_A   =>  seg_stA,
+          segment_B   =>  seg_stB,
+          segment_C   =>  seg_stC,
+          segment_D   =>  seg_stD,
+          segment_E   =>  seg_stE,
+			 segment_F   =>  seg_stF,
+		    segment_G   =>  seg_stG
+        );
+        
+
+    select_display_MINUTES <= '0';
+    select_display_SECONDS_ONES <= '0';
+    select_display_SECONDS_TENS  <= '0';
+	
+	minutes <= temp_minutes;
+	seconds_ones <= temp_sones;
+   seconds_tens <= temp_stens;
+	
+	
+		
+end architecture;

--- a/tb_calosc.vhd
+++ b/tb_calosc.vhd
@@ -1,0 +1,363 @@
+--------------------------------------------------------------------------------
+-- Company: 
+-- Engineer:
+--
+-- Create Date:   22:56:52 01/25/2022
+-- Design Name:   
+-- Module Name:   C:/1FPGA/boxing_timer_numberone/test_with_seconds_displays.vhd
+-- Project Name:  boxing_timer_numberone
+-- Target Device:  
+-- Tool versions:  
+-- Description:   
+-- 
+-- VHDL Test Bench Created by ISE for module: segmentdriver
+-- 
+-- Dependencies:
+-- 
+-- Revision:
+-- Revision 0.01 - File Created
+-- Additional Comments:
+--
+-- Notes: 
+-- This testbench has been automatically generated using types std_logic and
+-- std_logic_vector for the ports of the unit under test.  Xilinx recommends
+-- that these types always be used for the top-level I/O of a design in order
+-- to guarantee that the testbench will bind correctly to the post-implementation 
+-- simulation model.
+--------------------------------------------------------------------------------
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+-- Uncomment the following library declaration if using
+-- arithmetic functions with Signed or Unsigned values
+--USE ieee.numeric_std.ALL;
+ 
+ENTITY test_with_seconds_displays IS
+END test_with_seconds_displays;
+ 
+ARCHITECTURE behavior OF test_with_seconds_displays IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT segmentdriver
+    PORT(
+         clk : IN  std_logic;
+         rst : IN  std_logic;
+         minutes : OUT  std_logic_vector(3 downto 0);
+         seconds_ones : OUT  std_logic_vector(3 downto 0);
+         seconds_tens : OUT  std_logic_vector(3 downto 0);
+         seg_A : OUT  std_logic;
+         seg_B : OUT  std_logic;
+         seg_C : OUT  std_logic;
+         seg_D : OUT  std_logic;
+         seg_E : OUT  std_logic;
+         seg_F : OUT  std_logic;
+         seg_G : OUT  std_logic;
+         seg_soA : OUT  std_logic;
+         seg_soB : OUT  std_logic;
+         seg_soC : OUT  std_logic;
+         seg_soD : OUT  std_logic;
+         seg_soE : OUT  std_logic;
+         seg_soF : OUT  std_logic;
+         seg_soG : OUT  std_logic;
+         seg_stA : OUT  std_logic;
+         seg_stB : OUT  std_logic;
+         seg_stC : OUT  std_logic;
+         seg_stD : OUT  std_logic;
+         seg_stE : OUT  std_logic;
+         seg_stF : OUT  std_logic;
+         seg_stG : OUT  std_logic;
+         select_display_MINUTES : OUT  std_logic;
+         select_display_SECONDS_ONES : OUT  std_logic;
+         select_display_SECONDS_TENS : OUT  std_logic
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal clk : std_logic := '0';
+   signal rst : std_logic := '0';
+
+ 	--Outputs
+   signal minutes : std_logic_vector(3 downto 0);
+   signal seconds_ones : std_logic_vector(3 downto 0);
+   signal seconds_tens : std_logic_vector(3 downto 0);
+   signal seg_A : std_logic;
+   signal seg_B : std_logic;
+   signal seg_C : std_logic;
+   signal seg_D : std_logic;
+   signal seg_E : std_logic;
+   signal seg_F : std_logic;
+   signal seg_G : std_logic;
+   signal seg_soA : std_logic;
+   signal seg_soB : std_logic;
+   signal seg_soC : std_logic;
+   signal seg_soD : std_logic;
+   signal seg_soE : std_logic;
+   signal seg_soF : std_logic;
+   signal seg_soG : std_logic;
+   signal seg_stA : std_logic;
+   signal seg_stB : std_logic;
+   signal seg_stC : std_logic;
+   signal seg_stD : std_logic;
+   signal seg_stE : std_logic;
+   signal seg_stF : std_logic;
+   signal seg_stG : std_logic;
+   signal select_display_MINUTES : std_logic;
+   signal select_display_SECONDS_ONES : std_logic;
+   signal select_display_SECONDS_TENS : std_logic;
+
+   -- Clock period definitions
+   constant clk_period : time := 1 ns;
+ 
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: segmentdriver PORT MAP (
+          clk => clk,
+          rst => rst,
+          minutes => minutes,
+          seconds_ones => seconds_ones,
+          seconds_tens => seconds_tens,
+          seg_A => seg_A,
+          seg_B => seg_B,
+          seg_C => seg_C,
+          seg_D => seg_D,
+          seg_E => seg_E,
+          seg_F => seg_F,
+          seg_G => seg_G,
+          seg_soA => seg_soA,
+          seg_soB => seg_soB,
+          seg_soC => seg_soC,
+          seg_soD => seg_soD,
+          seg_soE => seg_soE,
+          seg_soF => seg_soF,
+          seg_soG => seg_soG,
+          seg_stA => seg_stA,
+          seg_stB => seg_stB,
+          seg_stC => seg_stC,
+          seg_stD => seg_stD,
+          seg_stE => seg_stE,
+          seg_stF => seg_stF,
+          seg_stG => seg_stG,
+          select_display_MINUTES => select_display_MINUTES,
+          select_display_SECONDS_ONES => select_display_SECONDS_ONES,
+          select_display_SECONDS_TENS => select_display_SECONDS_TENS
+        );
+
+   -- Clock process definitions
+   clk_process :process
+   begin
+		clk <= '0';
+		wait for clk_period/2;
+		clk <= '1';
+		wait for clk_period/2;
+   end process;
+ 
+
+   -- Stimulus process
+   stim_proc: process
+   begin		
+      -- hold reset state for 100 ns.
+      wait for 1 ns;	
+
+      wait for clk_period*10;
+
+      -- insert stimulus here 
+rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		rst <= '0';
+      wait for clk_period*1;
+		
+      wait;
+   end process;
+
+END;


### PR DESCRIPTION
dla potomnych
zeby bylo
backup 
costamcostam

TUTAJ ZNAJDUJE SIĘ DZIAŁAJĄCY KOD NA LICZNIK CZASOWY (DOWOLNY)
KTÓRY KONWERUJE DO BCD
DO TEGO JEST JESZCZE DEKODER 7 SEGMEND DISPLAY
I DRIVER, KTORY LICZBY W BCD WRZUCA NA 7 SD


NIE RUSZAC TEGO KODU -- WERSJA BACKUP
ALE GDYBY BYLA POTRZEBNA
ODPOWIEDNIE NAZWY PLIKOW POZMIENIAC ZEBY SIE ZGADZALO Z ENTITY

